### PR TITLE
restrict service types

### DIFF
--- a/doc/node_registry.example.json
+++ b/doc/node_registry.example.json
@@ -14,13 +14,13 @@
             {
                 "name": "geoserver",
                 "url": "https://infomatics-dcs.cs.toronto.edu/geoserver",
-                "type": ["geoserver"],
+                "type": ["data", "service-wps", "service-wms"],
                 "documentation": "https://docs.geoserver.org/",
                 "description": "GeoServer is a server that allows users to view and edit geospatial data."
             }, {
                 "name": "weaver",
                 "url": "https://infomatics-dcs.cs.toronto.edu/weaver",
-                "type": ["ems"],
+                "type": ["service-ogcapi"],
                 "documentation": "https://pavics-weaver.readthedocs.io",
                 "description": "An OGC-API flavored Execution Management Service"
             }

--- a/doc/node_registry.example.json
+++ b/doc/node_registry.example.json
@@ -20,7 +20,7 @@
             }, {
                 "name": "weaver",
                 "url": "https://infomatics-dcs.cs.toronto.edu/weaver",
-                "type": ["service-ogcapi"],
+                "type": ["service-ogcapi_processes"],
                 "documentation": "https://pavics-weaver.readthedocs.io",
                 "description": "An OGC-API flavored Execution Management Service"
             }

--- a/node_registry.schema.json
+++ b/node_registry.schema.json
@@ -59,7 +59,8 @@
                                 "type": "array",
                                 "minItems": 1,
                                 "items": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "pattern": "^catalog|data|jupyterhub|other|service-(wps|wms|wfs|wcs|ogcapi)$"
                                 }
                             },
                             "documentation": {

--- a/node_registry.schema.json
+++ b/node_registry.schema.json
@@ -60,7 +60,7 @@
                                 "minItems": 1,
                                 "items": {
                                     "type": "string",
-                                    "pattern": "^catalog|data|jupyterhub|other|service-(wps|wms|wfs|wcs|ogcapi)$"
+                                    "pattern": "^catalog|data|jupyterhub|other|service-(wps|wms|wfs|wcs|ogcapi_processes)$"
                                 }
                             },
                             "documentation": {

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -261,7 +261,7 @@ class TestOnlineNodeInitialUpdateWithValidServicesAndVersion(ValidResponseTests,
             {
                 "url": "http://example.com",
                 "name": "thredds",
-                "type": ["thredds"],
+                "type": ["data"],
                 "documentation": "http://doc.example.com",
                 "description": "service description",
             }
@@ -277,7 +277,7 @@ class TestOnlineNodeInitialUpdateWithInvalidVersion(InvalidResponseTests, Initia
             {
                 "url": "http://example.com",
                 "name": "thredds",
-                "type": ["thredds"],
+                "type": ["data"],
                 "documentation": "http://doc.example.com",
                 "description": "service description",
             }
@@ -294,7 +294,7 @@ class TestOnlineNodeUpdateWithValidServicesAndVersion(ValidResponseTests, NonIni
             {
                 "url": "http://example.com",
                 "name": "thredds",
-                "type": ["thredds"],
+                "type": ["data"],
                 "documentation": "http://doc.example.com",
                 "description": "service description",
             }
@@ -310,7 +310,7 @@ class TestOnlineNodeUpdateWithInvalidVersion(InvalidResponseTests, NonInitialTes
             {
                 "url": "http://example.com",
                 "name": "thredds",
-                "type": ["thredds"],
+                "type": ["data"],
                 "documentation": "http://doc.example.com",
                 "description": "service description",
             }
@@ -323,3 +323,19 @@ class TestOnlineNodeUpdateWithInvalidServices(InvalidResponseTests, NonInitialTe
     """Test when updates have previously been run and the reported services are not valid"""
 
     services = {"services": [{"bad_key": "some_value"}]}
+
+
+class TestOnlineNodeUpdateWithInvalidServiceTypes(InvalidResponseTests, NonInitialTests):
+    """Test when updates have previously been run and the reported services types are not valid"""
+
+    services = {
+        "services": [
+            {
+                "url": "http://example.com",
+                "name": "thredds",
+                "type": ["some-bad-service-type"],
+                "documentation": "http://doc.example.com",
+                "description": "service description",
+            }
+        ]
+    }


### PR DESCRIPTION
Restrict valid service types so that consumers of this data don't have to deal with arbitrary types.

Valid service types are now:

- catalog (eg. stac)
- data (eg. thredds, geoserver)
- jupyterhub (eg. jupyterhub)
- service-ogcapi_processes (eg.weaver)
- service-wps (eg. finch)
- service-wms
- service-wfs
- service-wcs
- other (anything else)
