### PR TITLE
update service definitions

### DIFF
--- a/doc/node_registry.example.json
+++ b/doc/node_registry.example.json
@@ -22,7 +22,7 @@
         "description": "GeoServer is a server that allows users to view and edit geospatial data.",
         "links": [
           {
-            "rel": "self",
+            "rel": "service",
             "type": "text/html",
             "href": "https://daccs-uoft.example.com/geoserver/"
           },
@@ -41,7 +41,7 @@
         "description": "An OGC-API flavored Execution Management Service",
         "links": [
           {
-            "rel": "self",
+            "rel": "service",
             "type": "application/json",
             "href": "https://daccs-uoft.example.com/weaver/"
           },
@@ -56,7 +56,7 @@
             "href": "https://daccs-uoft.example.com/weaver/"
           },
           {
-            "rel": "http://www.opengis.net/def/rel/ogc/1.0/conformance",
+            "rel": "conformance",
             "type": "application/json",
             "href": "https://daccs-uoft.example.com/weaver/conformance/"
           }

--- a/doc/node_registry.example.json
+++ b/doc/node_registry.example.json
@@ -1,32 +1,70 @@
 {
-    "UofT":{
-        "url": "http://daccs-uoft.example.com",
-        "date_added": "2023-05-04T17:09:07+0000",
-        "affiliation": "University of Toronto",
-        "description": "This is the best node there is!",
-        "icon_url": "https://icon.example.com",
-        "location": {
-            "longitude": -79.39, 
-            "latitude": 43.65
-        },
-        "contact": "somesupport@example.com",
-        "services": [
-            {
-                "name": "geoserver",
-                "url": "https://infomatics-dcs.cs.toronto.edu/geoserver",
-                "type": ["data", "service-wps", "service-wms"],
-                "documentation": "https://docs.geoserver.org/",
-                "description": "GeoServer is a server that allows users to view and edit geospatial data."
-            }, {
-                "name": "weaver",
-                "url": "https://infomatics-dcs.cs.toronto.edu/weaver",
-                "type": ["service-ogcapi_processes"],
-                "documentation": "https://pavics-weaver.readthedocs.io",
-                "description": "An OGC-API flavored Execution Management Service"
-            }
+  "UofT": {
+    "url": "http://daccs-uoft.example.com",
+    "date_added": "2023-05-04T17:09:07+0000",
+    "affiliation": "University of Toronto",
+    "description": "This is the best node there is!",
+    "icon_url": "https://icon.example.com",
+    "location": {
+      "longitude": -79.39,
+      "latitude": 43.65
+    },
+    "contact": "somesupport@example.com",
+    "services": [
+      {
+        "name": "geoserver",
+        "keywords": [
+          "data",
+          "service-wps",
+          "service-wms",
+          "service-wfs"
         ],
-        "last_updated": "2023-05-04T17:09:07+0000",
-        "version": "1.26.0",
-        "status": "offline"
-    }
+        "description": "GeoServer is a server that allows users to view and edit geospatial data.",
+        "links": [
+          {
+            "rel": "self",
+            "type": "text/html",
+            "href": "https://daccs-uoft.example.com/geoserver/"
+          },
+          {
+            "rel": "service-doc",
+            "type": "text/html",
+            "href": "https://docs.geoserver.org/"
+          }
+        ]
+      },
+      {
+        "name": "weaver",
+        "keywords": [
+          "service-ogcapi_processes"
+        ],
+        "description": "An OGC-API flavored Execution Management Service",
+        "links": [
+          {
+            "rel": "self",
+            "type": "application/json",
+            "href": "https://daccs-uoft.example.com/weaver/"
+          },
+          {
+            "rel": "service-doc",
+            "type": "text/html",
+            "href": "https://pavics-weaver.readthedocs.io/"
+          },
+          {
+            "rel": "service-desc",
+            "type": "text/html",
+            "href": "https://daccs-uoft.example.com/weaver/"
+          },
+          {
+            "rel": "http://www.opengis.net/def/rel/ogc/1.0/conformance",
+            "type": "application/json",
+            "href": "https://daccs-uoft.example.com/weaver/conformance/"
+          }
+        ]
+      }
+    ],
+    "last_updated": "2023-05-04T17:09:07+0000",
+    "version": "1.26.0",
+    "status": "offline"
+  }
 }

--- a/node_registry.schema.json
+++ b/node_registry.schema.json
@@ -1,100 +1,136 @@
 {
-	"$schema": "https://json-schema.org/draft/2020-12/schema",
-    "patternProperties": {
-    	"^[a-zA-Z0-9_-]+$": {
-        	"type": "object",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "patternProperties": {
+    "^[a-zA-Z0-9_-]+$": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^https?://"
+        },
+        "date_added": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "affiliation": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "icon_url": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^https?://"
+        },
+        "location": {
+          "required": [
+            "latitude",
+            "longitude"
+          ],
+          "type": "object",
+          "properties": {
+            "latitude": {
+              "type": "number",
+              "minimum": -90,
+              "maximum": 90
+            },
+            "longitude": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180
+            }
+          }
+        },
+        "services": {
+          "type": "array",
+          "items": {
+            "$anchor": "service",
+            "type": "object",
+            "required": [
+              "name",
+              "keywords",
+              "description",
+              "links"
+            ],
             "properties": {
-            	"url": {
-                    "type": "string",
-                	"format": "uri", 
-                    "pattern": "^https?://"
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "keywords": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "pattern": "^catalog|data|jupyterhub|other|service-(wps|wms|wfs|wcs|ogcapi_processes)$"
+                }
+              },
+              "description": {
+                "type": "string",
+                "minLength": 1
+              },
+              "links": {
+                "type": "array",
+                "items": {
+                  "$ref": "https://json-schema.org/draft/2020-12/links"
                 },
-                "date_added": {
-                    "type": "string",
-                	"format": "date-time"
-                },
-                "affiliation": {
-                	"type": "string"
-                },
-                "description": {
-                	"type": "string"
-                },
-                "icon_url": {
-                    "type": "string",
-                	"format": "uri",
-                    "pattern": "^https?://"
-                },
-                "location": {
-                  "required": [ "latitude", "longitude" ],
-                  "type": "object",
-                  "properties": {
-                    "latitude": {
-                      "type": "number",
-                      "minimum": -90,
-                      "maximum": 90
-                    },
-                    "longitude": {
-                      "type": "number",
-                      "minimum": -180,
-                      "maximum": 180
+                "allOf": [
+                  {
+                    "contains": {
+                      "type": "object",
+                      "properties": {
+                        "rel": {
+                          "type": "string",
+                          "const": "self"
+                        }
+                      }
+                    }
+                  },
+                  {
+                    "contains": {
+                      "type": "object",
+                      "properties": {
+                        "rel": {
+                          "type": "string",
+                          "const": "service-doc"
+                        }
+                      }
                     }
                   }
-                },
-                "services": {
-                	"type": "array",
-                    "items": {
-                    	"type": "object",
-                        "required": ["url", "name", "type", "documentation", "description"],
-                        "properties": {
-                        	"url": {
-                            	"type": "string",
-                                "format": "uri",
-                                "pattern": "^https?://"
-                            },
-                          	"name": {
-                            	"type": "string",
-                                "minLength": 1
-                            },
-                            "type": {
-                                "type": "array",
-                                "minItems": 1,
-                                "items": {
-                                    "type": "string",
-                                    "pattern": "^catalog|data|jupyterhub|other|service-(wps|wms|wfs|wcs|ogcapi_processes)$"
-                                }
-                            },
-                            "documentation": {
-                            	"type": "string",
-                                "format": "uri",
-                                "pattern": "^https?://"
-                            },
-                            "description": {
-                            	"type": "string",
-                                "minLength": 1
-                            }
-                        }
-                    }
-                },
-                "last_updated": {
-                    "type": "string",
-                	"format": "date-time"
-                },
-                "version": {
-                	"type": "string",
-                    "pattern": "^[0-9\\.]+$"
-                },
-                "status": {
-                	"type": "string",
-                    "enum": ["offline", "online"]
-                },
-                "contact": {
-                    "type": "string",
-                	"format": "email"
-                }
-            },
-            "required": ["url", "date_added", "contact"],
-            "additionalProperties": false
+                ]
+              }
+            }
+          }
+        },
+        "last_updated": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^[0-9\\.]+$"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "offline",
+            "online"
+          ]
+        },
+        "contact": {
+          "type": "string",
+          "format": "email"
         }
-    },
-    "additionalProperties": false
+      },
+      "required": [
+        "url",
+        "date_added",
+        "contact"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
 }

--- a/node_registry.schema.json
+++ b/node_registry.schema.json
@@ -83,7 +83,7 @@
                       "properties": {
                         "rel": {
                           "type": "string",
-                          "const": "self"
+                          "const": "service"
                         }
                       }
                     }

--- a/tests/fixtures/links-schema-cache.json
+++ b/tests/fixtures/links-schema-cache.json
@@ -1,0 +1,85 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json-schema.org/draft/2020-12/links",
+    "title": "Link Description Object",
+
+    "type": "object",
+    "properties": {
+        "anchor": {
+            "type": "string",
+            "format": "uri-template"
+        },
+        "anchorPointer": {
+            "type": "string",
+            "anyOf": [
+                { "format": "json-pointer" },
+                { "format": "relative-json-pointer" }
+            ]
+        },
+        "rel": {
+            "anyOf": [
+                { "type": "string" },
+                {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "minItems": 1
+                }
+            ]
+        },
+        "href": {
+            "type": "string",
+            "format": "uri-template"
+        },
+        "hrefSchema": {
+            "$dynamicRef": "https://json-schema.org/draft/2020-12/hyper-schema#meta",
+            "default": false
+        },
+        "templatePointers": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string",
+                "anyOf": [
+                    { "format": "json-pointer" },
+                    { "format": "relative-json-pointer" }
+                ]
+            }
+        },
+        "templateRequired": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "targetSchema": {
+            "$dynamicRef": "https://json-schema.org/draft/2020-12/hyper-schema#meta",
+            "default": true
+        },
+        "targetMediaType": {
+            "type": "string"
+        },
+        "targetHints": {},
+        "headerSchema": {
+            "$dynamicRef": "https://json-schema.org/draft/2020-12/hyper-schema#meta",
+            "default": true
+        },
+        "submissionMediaType": {
+            "type": "string",
+            "default": "application/json"
+        },
+        "submissionSchema": {
+            "$dynamicRef": "https://json-schema.org/draft/2020-12/hyper-schema#meta",
+            "default": true
+        },
+        "$comment": {
+            "type": "string"
+        }
+    },
+    "required": [ "rel", "href" ]
+}

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -12,7 +12,7 @@ GOOD_SERVICES = {
             "keywords": ["data", "service-wps", "service-wms", "service-wfs"],
             "description": "GeoServer is a server that allows users to view and edit geospatial data.",
             "links": [
-                {"rel": "self", "type": "application/json", "href": "https://daccs-uoft.example.com/geoserver/"},
+                {"rel": "service", "type": "application/json", "href": "https://daccs-uoft.example.com/geoserver/"},
                 {"rel": "service-doc", "type": "text/html", "href": "https://docs.geoserver.org/"},
             ],
         },
@@ -21,7 +21,7 @@ GOOD_SERVICES = {
             "keywords": ["service-ogcapi_processes"],
             "description": "An OGC-API flavored Execution Management Service",
             "links": [
-                {"rel": "self", "type": "application/json", "href": "https://daccs-uoft.example.com/weaver/"},
+                {"rel": "service", "type": "application/json", "href": "https://daccs-uoft.example.com/weaver/"},
                 {"rel": "service-doc", "type": "text/html", "href": "https://pavics-weaver.readthedocs.io/"},
                 {
                     "rel": "http://www.opengis.net/def/rel/ogc/1.0/conformance",

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -5,11 +5,50 @@ from copy import deepcopy
 import pytest
 from daccs_node_registry import update
 
+GOOD_SERVICES = {
+    "services": [
+        {
+            "name": "geoserver",
+            "keywords": ["data", "service-wps", "service-wms", "service-wfs"],
+            "description": "GeoServer is a server that allows users to view and edit geospatial data.",
+            "links": [
+                {"rel": "self", "type": "application/json", "href": "https://daccs-uoft.example.com/geoserver/"},
+                {"rel": "service-doc", "type": "text/html", "href": "https://docs.geoserver.org/"},
+            ],
+        },
+        {
+            "name": "weaver",
+            "keywords": ["service-ogcapi_processes"],
+            "description": "An OGC-API flavored Execution Management Service",
+            "links": [
+                {"rel": "self", "type": "application/json", "href": "https://daccs-uoft.example.com/weaver/"},
+                {"rel": "service-doc", "type": "text/html", "href": "https://pavics-weaver.readthedocs.io/"},
+                {
+                    "rel": "http://www.opengis.net/def/rel/ogc/1.0/conformance",
+                    "type": "application/json",
+                    "href": "https://example.com/weaver/conformance/",
+                },
+            ],
+        },
+    ]
+}
+
 
 @pytest.fixture(autouse=True)
 def updated_registry(mocker):
     """Mock the _write_registry function so that nothing is actually written to disk during the tests run"""
     yield mocker.patch.object(update, "_write_registry")
+
+
+@pytest.fixture(autouse=True)
+def links_json_schema(requests_mock, request):
+    """
+    Mock the `requests.get` call to the json-schema links hyper-schema so that these tests can be run offline if needed.
+    """
+    this_dir = os.path.dirname(request.fspath)
+    with open(os.path.join(this_dir, "fixtures", "links-schema-cache.json")) as f:
+        content = f.read()
+    requests_mock.get("https://json-schema.org/draft/2020-12/links", text=content)
 
 
 @pytest.fixture
@@ -256,66 +295,26 @@ class TestInitialUpdateInvalidServices(InvalidResponseTests, InitialTests):
 class TestOnlineNodeInitialUpdateWithValidServicesAndVersion(ValidResponseTests, InitialTests):
     """Test when no updates have previously been run and the reported services and version are valid"""
 
-    services = {
-        "services": [
-            {
-                "url": "http://example.com",
-                "name": "thredds",
-                "type": ["data"],
-                "documentation": "http://doc.example.com",
-                "description": "service description",
-            }
-        ]
-    }
+    services = GOOD_SERVICES
 
 
 class TestOnlineNodeInitialUpdateWithInvalidVersion(InvalidResponseTests, InitialTests):
     """Test when no updates have previously been run and the reported version is not valid"""
 
-    services = {
-        "services": [
-            {
-                "url": "http://example.com",
-                "name": "thredds",
-                "type": ["data"],
-                "documentation": "http://doc.example.com",
-                "description": "service description",
-            }
-        ]
-    }
+    services = GOOD_SERVICES
     version = {"version": "abc123"}
 
 
 class TestOnlineNodeUpdateWithValidServicesAndVersion(ValidResponseTests, NonInitialTests):
     """Test when updates have previously been run and the reported services and version are valid"""
 
-    services = {
-        "services": [
-            {
-                "url": "http://example.com",
-                "name": "thredds",
-                "type": ["data"],
-                "documentation": "http://doc.example.com",
-                "description": "service description",
-            }
-        ]
-    }
+    services = GOOD_SERVICES
 
 
 class TestOnlineNodeUpdateWithInvalidVersion(InvalidResponseTests, NonInitialTests):
     """Test when updates have previously been run and the reported version is not valid"""
 
-    services = {
-        "services": [
-            {
-                "url": "http://example.com",
-                "name": "thredds",
-                "type": ["data"],
-                "documentation": "http://doc.example.com",
-                "description": "service description",
-            }
-        ]
-    }
+    services = GOOD_SERVICES
     version = {"version": "abc123"}
 
 
@@ -325,17 +324,11 @@ class TestOnlineNodeUpdateWithInvalidServices(InvalidResponseTests, NonInitialTe
     services = {"services": [{"bad_key": "some_value"}]}
 
 
-class TestOnlineNodeUpdateWithInvalidServiceTypes(InvalidResponseTests, NonInitialTests):
-    """Test when updates have previously been run and the reported services types are not valid"""
+class TestOnlineNodeUpdateWithInvalidServiceKeywords(InvalidResponseTests, NonInitialTests):
+    """Test when updates have previously been run and the reported services keywords are not valid"""
 
-    services = {
-        "services": [
-            {
-                "url": "http://example.com",
-                "name": "thredds",
-                "type": ["some-bad-service-type"],
-                "documentation": "http://doc.example.com",
-                "description": "service description",
-            }
-        ]
-    }
+    services = deepcopy(GOOD_SERVICES)
+
+    @pytest.fixture(scope="class", autouse=True)
+    def bad_keywords(self):
+        self.services["services"][0]["keywords"] = ["something-bad"]


### PR DESCRIPTION
Update service definitions to include the following keys only:

- name
- keywords (replaces `types`)
- description
- links (schema defined by `https://json-schema.org/draft/2020-12/links` with the additional restriction that there must be at least one `"rel"` key with the value `"self"` and one with the valued `"service-doc"`)

`"service"` contains an "href" that refers to the context URI of the service (ie. what the `"url"` key used to refer to)
`"service-doc"` contains an "href" that refers to the documentation of the service (ie. what the `"documentation"` key used to refer to)

See https://www.iana.org/assignments/link-relations/link-relations.xhtml for link relation definitions.

Resolves #2 
Resolves #3 