### PR TITLE
automatically set date-added field

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ In which case, please submit the pull request with the new URL and the Executive
 
 When making changes to the node_registry.json file please only change or add the following values:
   - url (the publicly accessible URL of your node)
-  - date_added (the date the node was originally added to the network, this should only be updated once)
   - affiliation (the name of your organization, optional)
   - description (a short description of your node, optional)
   - icon_url (a publicly accessible url to an icon image for your node, optional)

--- a/daccs_node_registry/update.py
+++ b/daccs_node_registry/update.py
@@ -87,6 +87,8 @@ def update_registry() -> None:
         else:
             print(f"successfully updated Node named {name} at url {data['url']}")
             registry[name]["last_updated"] = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
+            if registry[name].get("date_added") is None:
+                registry[name]["date_added"] = registry[name]["last_updated"]
             data["status"] = "online"
 
     _write_registry(registry)

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -195,8 +195,12 @@ class InitialTests:
 
     @pytest.fixture(autouse=True)
     def setup(self, example_node_name, example_initial_registry, example_registry_content, requests_mock):
+        services = deepcopy(self.services)
+        for s in services.values():
+            if isinstance(s, dict) and "date_added" in s:
+                s.pop("date_added")
         requests_mock.get(
-            os.path.join(example_registry_content[example_node_name]["url"], "services"), json=self.services
+            os.path.join(example_registry_content[example_node_name]["url"], "services"), json=services
         )
         requests_mock.get(
             os.path.join(example_registry_content[example_node_name]["url"], "version"), json=self.version


### PR DESCRIPTION
Previously, the "date-added" field needed to be set manually when the request for the node was created.

This cause some potential issues:

- the format of the date wasn't strictly enforced which could lead to the dates being in slightly different formats for different nodes if we weren't careful
- the reported date would be the date when the node was _requested_ to be added to the registry, not the date that it was actually added.

To fix this, we should automatically set the "date-added" field the first time that the full node content is collected by the update scripts. This guarantees that the value of "date-added" corresponds to the date that the node is fully online and accessible by the registry. 