### PR TITLE
add initial UofT and PAVICS nodes

### DIFF
--- a/node_registry.json
+++ b/node_registry.json
@@ -22,5 +22,17 @@
       "latitude": 45.5
     },
     "contact": "pavics@ouranos.ca"
+  },
+  "Hirondelle": {
+    "url": "https://hirondelle.crim.ca",
+    "date_added": "2023-07-06T17:26:09.434813-04:00",
+    "affiliation": "Computer Research Institute of Montréal (CRIM)",
+    "description": "Development server to evaluate new features of the bird-house deployment architecture.",
+    "icon_url": "https://www.crim.ca/wp-content/uploads/2020/10/logo-color-300x61.png",
+    "location": {
+      "longitude": -73.627318,
+      "latitude": 45.5303976
+    },
+    "contact": "info@crim.ca"
   }
 }

--- a/node_registry.json
+++ b/node_registry.json
@@ -1,1 +1,26 @@
-{}
+{
+  "UofT": {
+    "url": "https://daccs.cs.toronto.edu",
+    "date_added": "2023-07-06T19:06:56.085299+00:00",
+    "affiliation": "University of Toronto",
+    "description": "A DACCS node hosted at the University of Toronto.",
+    "icon_url": "https://daccs.cs.toronto.edu/logo",
+    "location": {
+      "longitude": -79.39,
+      "latitude": 43.65
+    },
+    "contact": "daccs-info@cs.toronto.edu"
+  },
+  "PAVICS": {
+    "url": "https://pavics.ouranos.ca",
+    "date_added": "2023-07-06T19:06:56.085299+00:00",
+    "affiliation": "Ouranos",
+    "description": "PAVICS is a virtual laboratory facilitating the analysis of climate data.",
+    "icon_url": "https://pavics.ouranos.ca/assets/images/pavics_v_white.svg",
+    "location": {
+      "longitude": -71.21,
+      "latitude": 46.81
+    },
+    "contact": "pavics@ouranos.ca"
+  }
+}

--- a/node_registry.json
+++ b/node_registry.json
@@ -18,8 +18,8 @@
     "description": "PAVICS is a virtual laboratory facilitating the analysis of climate data.",
     "icon_url": "https://pavics.ouranos.ca/assets/images/pavics_v_white.svg",
     "location": {
-      "longitude": -71.21,
-      "latitude": 46.81
+      "longitude": -73.57,
+      "latitude": 45.5
     },
     "contact": "pavics@ouranos.ca"
   }


### PR DESCRIPTION
Adds the initial configuration for the UofT and PAVICS DACCS nodes to the registry.

Note:
- latitude/longitude values are approximate for the cities of Toronto/Quebec
- date_added should probably be updated again just before this PR is merged (unless #12 is merged first and this PR is updated to reflect that change)
