### PR TITLE
Create a git action workflow to update node_registry.json daily

### DIFF
--- a/.github/workflows/registry-update.yml
+++ b/.github/workflows/registry-update.yml
@@ -5,6 +5,8 @@ on:
   workflow_dispatch:
 jobs:
   update:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/registry-update.yml
+++ b/.github/workflows/registry-update.yml
@@ -1,0 +1,29 @@
+name: Registry Update
+on:
+  schedule:
+    - cron: 0 0 * * *
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up python for updating
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: 'pip'
+      - name: Install python dependencies
+        run: |
+          pip install -r ./requirements.txt
+      - name: Run update script
+        run: |
+          python3 ./daccs_node_registry/update.py
+      - name: commit changes to "current-registry" branch
+        run: |
+          git config user.name daccs-auto-update
+          git config user.email github-actions@github.com
+          git checkout -b current-registry
+          git add node_registry.json
+          git commit -m "daccs registry update" && git push --set-upstream origin current-registry

--- a/.github/workflows/registry-update.yml
+++ b/.github/workflows/registry-update.yml
@@ -2,6 +2,7 @@ name: Registry Update
 on:
   schedule:
     - cron: 0 0 * * *
+  workflow_dispatch:
 jobs:
   update:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -4,7 +4,16 @@ The purpose of this repository is to serve as a single source of truth for infor
 constitute the DACCS network at any time. Active DACCS nodes will periodically retrieve this file and update their 
 own local databases with the information contained within it.
 
-## Usage
+## Access the registry
+
+The registry can be accessed at the following URL:
+
+https://raw.githubusercontent.com/DACCS-Climate/DACCS-node-registry/current_registry/node_registry.json
+
+The registry is a JSON string that contains information about all nodes in the DACCS network. This file is regularly
+updated so that the information provided is up-to-date.
+
+## Add or update information about a DACCS node
 
 This repo is only meant to be updated by administrators who either (i) manage DACCS nodes or, (ii) want to deploy a 
 new DACCS Node. 


### PR DESCRIPTION
This creates a github action that:
- runs the `update.py` script to update the `node_registry.json` file
- commits this change to the `current_registry` branch (if a change occurred)

This action runs once daily and can also be triggered manually from the Actions tab (on github)

This will allow us to not have to update the main branch with daily changes. Scripts/sites that access the registry can do so by getting it from the current_registry branch instead.

Resolves #4 