### PR TITLE
create links key at node level in registry

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/registry-update.md
+++ b/.github/PULL_REQUEST_TEMPLATE/registry-update.md
@@ -10,14 +10,14 @@ I would like to (choose one):
 - only submit changes to the `node_registry.json` file
 - only make changes to a single Node listed in the registry in the pull request
 - only make changes to the following keys (all others are updated automatically):
-  - url
-  - date_added
-  - affiliation
-  - description
-  - icon_url
-  - location
-  - contact
+  - `date_added`
+  - `affiliation`
+  - `description`
+  - `location`
+  - `contact`
+  - `links`
 - you may also change the name of the node (the key at the root of the json string) but ensure that the name is not already in use
+- see `README.md` for a description of the values and see `doc/node_registry.example.json` for examples.
 
 ## Next Steps
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,34 @@ If you are already part of the DACCS Network and details about your node have ch
 In which case, please submit the pull request with the new URL and the Executive Committee will approve it quickly.
 
 When making changes to the node_registry.json file please only change or add the following values:
-  - url (the publicly accessible URL of your node)
-  - date_added (the date the node was originally added to the network, this should only be updated once)
-  - affiliation (the name of your organization, optional)
-  - description (a short description of your node, optional)
-  - icon_url (a publicly accessible url to an icon image for your node, optional)
-  - location (latitude and longitude of your organization, optional)
-  - contact (an email address that can be used by users to contact you if they have questions about your node)
+  - `date_added` (the date the node was originally added to the network, this should only be updated once)
+  - `affiliation` (the name of your organization, optional)
+  - `description` (a short description of your node, optional)
+  - `location` (latitude and longitude of your organization, optional)
+  - `contact` (an email address that can be used by users to contact you if they have questions about your node)
+  - `links -> version` (see links table below)
+  - `links -> collection` (see links table below)
+  - `links -> service` (see links table below)
+
+The `links` key should contain links that describe and provide access to your node. Please see the table below
+for a description of some link values that may be useful. Only `version`, `collection`, and `home` are required.
+
+| `rel`                                              | Meaning                                                                                                                                                         | 
+|----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `about`                                            | URL to a summary or purpose of the node                                                                                                                         |
+| `author`                                           | URL to the maintainer/institution of the node                                                                                                                   |
+| `acl`                                              | Endpoint to Access Control List such as the `/magpie` endpoint or another access management method                                                              |
+| `collection`                                       | URL to the `/services` endpoint of the node (required)                                                                                                          |
+| `cite-as` <br> `publication`                       | Attribution by researchers to reference the node when using it for publications                                                                                 |
+| `copyright` <br> `license` <br> `terms-of-service` | Legal use of the node                                                                                                                                           |
+| `describedby`                                      | URL to full documentation and details of the node, its purpose and so on                                                                                        | 
+| `edit`                                             | A self-reference to https://github.com/DACCS-Climate/DACCS-node-registry or anywhere that the specific node registry entry to redirect users where to update it | 
+| `service`                                          | URL to the landing page of the node (required)                                                                                                                  |
+| `service-desc`                                     | URL to the `/components` endpoint of the node (if available)                                                                                                    |
+| `icon`                                             | Logo of the institution of specific node                                                                                                                        | 
+| `status`                                           | URL to a monitoring service endpoint, such as `/canarie` or another alternative                                                                                 | 
+| `version`                                          | URL to the `/version` endpoint of the node (required)                                                                                                           |
+| `version-history`                                  | link to https://github.com/bird-house/birdhouse-deploy/blob/master/CHANGES.md or similar                                                                        |
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -20,35 +20,35 @@ plans on being a part of the network.
 If you are already part of the DACCS Network and details about your node have changed (e.g. url, contact email, etc.). 
 In which case, please submit the pull request with the new URL and the Executive Committee will approve it quickly.
 
-When making changes to the node_registry.json file please only change or add the following values:
+When making changes to the node_registry.json file please only change or add the following values (described using JSONPath syntax):
   - `date_added` (the date the node was originally added to the network, this should only be updated once)
   - `affiliation` (the name of your organization, optional)
   - `description` (a short description of your node, optional)
   - `location` (latitude and longitude of your organization, optional)
   - `contact` (an email address that can be used by users to contact you if they have questions about your node)
-  - `links -> version` (see links table below)
-  - `links -> collection` (see links table below)
-  - `links -> service` (see links table below)
+  - `links[?(@.rel == "version")]` (see links table below)
+  - `links[?(@.rel == "collection")]` (see links table below)
+  - `links[?(@.rel == "service")]` (see links table below)
 
 The `links` key should contain links that describe and provide access to your node. Please see the table below
 for a description of some link values that may be useful. Only `version`, `collection`, and `home` are required.
 
-| `rel`                                              | Meaning                                                                                                                                                         | 
-|----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `about`                                            | URL to a summary or purpose of the node                                                                                                                         |
-| `author`                                           | URL to the maintainer/institution of the node                                                                                                                   |
-| `acl`                                              | Endpoint to Access Control List such as the `/magpie` endpoint or another access management method                                                              |
-| `collection`                                       | URL to the `/services` endpoint of the node (required)                                                                                                          |
-| `cite-as` <br> `publication`                       | Attribution by researchers to reference the node when using it for publications                                                                                 |
-| `copyright` <br> `license` <br> `terms-of-service` | Legal use of the node                                                                                                                                           |
-| `describedby`                                      | URL to full documentation and details of the node, its purpose and so on                                                                                        | 
-| `edit`                                             | A self-reference to https://github.com/DACCS-Climate/DACCS-node-registry or anywhere that the specific node registry entry to redirect users where to update it | 
-| `service`                                          | URL to the landing page of the node (required)                                                                                                                  |
-| `service-desc`                                     | URL to the `/components` endpoint of the node (if available)                                                                                                    |
-| `icon`                                             | Logo of the institution of specific node                                                                                                                        | 
-| `status`                                           | URL to a monitoring service endpoint, such as `/canarie` or another alternative                                                                                 | 
-| `version`                                          | URL to the `/version` endpoint of the node (required)                                                                                                           |
-| `version-history`                                  | link to https://github.com/bird-house/birdhouse-deploy/blob/master/CHANGES.md or similar                                                                        |
+| `rel`                                              | Meaning                                                                                                                                                         | Required | 
+|----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
+| `about`                                            | URL to a summary or purpose of the node                                                                                                                         |          |
+| `author`                                           | URL to the maintainer/institution of the node                                                                                                                   |          |
+| `acl`                                              | Endpoint to Access Control List such as the `/magpie` endpoint or another access management method                                                              |          |
+| `collection`                                       | URL to the `/services` endpoint of the node                                                                                                                     | Yes      |
+| `cite-as` <br> `publication`                       | Attribution by researchers to reference the node when using it for publications                                                                                 |          |
+| `copyright` <br> `license` <br> `terms-of-service` | Legal use of the node                                                                                                                                           |          |
+| `describedby`                                      | URL to full documentation and details of the node, its purpose and so on                                                                                        |          | 
+| `edit`                                             | A self-reference to https://github.com/DACCS-Climate/DACCS-node-registry or anywhere that the specific node registry entry to redirect users where to update it |          | 
+| `service`                                          | URL to the landing page of the node                                                                                                                             | Yes      |
+| `service-desc`                                     | URL to the `/components` endpoint of the node (if available)                                                                                                    |          |
+| `icon`                                             | Logo of the institution of specific node                                                                                                                        |          | 
+| `status`                                           | URL to a monitoring service endpoint, such as `/canarie` or another alternative                                                                                 |          | 
+| `version`                                          | URL to the `/version` endpoint of the node                                                                                                                      | Yes      |
+| `version-history`                                  | link to https://github.com/bird-house/birdhouse-deploy/blob/master/CHANGES.md or similar                                                                        |          |
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -45,22 +45,22 @@ See the [node_registry.example.json](doc/node_registry.example.json) file for ex
 The `links` key should contain links that describe and provide access to your node. Please see the table below
 for a description of some link values that may be useful.
 
-| `rel`                                              | Meaning                                                                                                                                                         | Required | 
-|----------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|----------|
-| `about`                                            | URL to a summary or purpose of the node                                                                                                                         |          |
-| `author`                                           | URL to the maintainer/institution of the node                                                                                                                   |          |
-| `acl`                                              | Endpoint to Access Control List such as the `/magpie` endpoint or another access management method                                                              |          |
-| `collection`                                       | URL to the `/services` endpoint of the node                                                                                                                     | Yes      |
-| `cite-as` <br> `publication`                       | Attribution by researchers to reference the node when using it for publications                                                                                 |          |
-| `copyright` <br> `license` <br> `terms-of-service` | Legal use of the node                                                                                                                                           |          |
-| `describedby`                                      | URL to full documentation and details of the node, its purpose and so on                                                                                        |          | 
-| `edit`                                             | A self-reference to https://github.com/DACCS-Climate/DACCS-node-registry or anywhere that the specific node registry entry to redirect users where to update it |          | 
-| `service`                                          | URL to the landing page of the node                                                                                                                             | Yes      |
-| `service-desc`                                     | URL to the `/components` endpoint of the node (if available)                                                                                                    |          |
-| `icon`                                             | Logo of the institution of specific node                                                                                                                        |          | 
-| `status`                                           | URL to a monitoring service endpoint, such as `/canarie` or another alternative                                                                                 |          | 
-| `version`                                          | URL to the `/version` endpoint of the node                                                                                                                      | Yes      |
-| `version-history`                                  | link to https://github.com/bird-house/birdhouse-deploy/blob/master/CHANGES.md or similar                                                                        |          |
+| `rel`                                              | Meaning                                                                                    | Required |
+|----------------------------------------------------|--------------------------------------------------------------------------------------------|----------|
+| `about`                                            | link to a summary or purpose of the node                                                   |          |
+| `author`                                           | link to the website of the maintainer/institution of the node                              |          |
+| `acl`                                              | link to an Access Control List endpoint, such as `/magpie`                                 |          |
+| `collection`                                       | link to the `/services` endpoint of the node                                               | Yes      |
+| `cite-as` <br> `publication`                       | link to attribution/citation information for use when referencing the node in publications |          |
+| `copyright` <br> `license` <br> `terms-of-service` | link to legal information of the node                                                      |          |
+| `describedby`                                      | link to full documentation and details of the node, its purpose and so on                  |          |
+| `edit`                                             | A self-reference to this repo or anywhere a user can request an update to a node           |          |
+| `service`                                          | link to the landing page of the node                                                       | Yes      |
+| `service-desc`                                     | link to the `/components` endpoint of the node                                             |          |
+| `icon`                                             | link to the logo of the specific node (or the maintainer/institution's logo)               |          |
+| `status`                                           | link to a monitoring service endpoint, such as `/canarie`                                  |          |
+| `version`                                          | link to the `/version` endpoint of the node                                                | Yes      |
+| `version-history`                                  | link to https://github.com/bird-house/birdhouse-deploy/blob/master/CHANGES.md or similar   |          |
 
 ## Admin instructions
 

--- a/README.md
+++ b/README.md
@@ -20,15 +20,19 @@ plans on being a part of the network.
 If you are already part of the DACCS Network and details about your node have changed (e.g. url, contact email, etc.). 
 In which case, please submit the pull request with the new URL and the Executive Committee will approve it quickly.
 
-When making changes to the node_registry.json file please only change or add the following values (described using JSONPath syntax):
+When making changes to the node_registry.json file please only change or add the following values:
   - `date_added` (the date the node was originally added to the network, this should only be updated once)
   - `affiliation` (the name of your organization, optional)
   - `description` (a short description of your node, optional)
   - `location` (latitude and longitude of your organization, optional)
   - `contact` (an email address that can be used by users to contact you if they have questions about your node)
-  - `links[?(@.rel == "version")]` (see links table below)
-  - `links[?(@.rel == "collection")]` (see links table below)
-  - `links[?(@.rel == "service")]` (see links table below)
+  - `links` (contains a list of link objects that describe URLs for each node)
+    - each link object must contain a `rel` and `href` key. 
+    - some link objects are required, see the table below for details
+
+See the [node_registry.example.json](doc/node_registry.example.json) file for example values.
+
+#### Links
 
 The `links` key should contain links that describe and provide access to your node. Please see the table below
 for a description of some link values that may be useful. Only `version`, `collection`, and `home` are required.

--- a/daccs_node_registry/update.py
+++ b/daccs_node_registry/update.py
@@ -57,17 +57,10 @@ def update_registry() -> None:
                 services_url = link["href"]
             elif link["rel"] == "version":
                 version_url = link["href"]
-        if services_url is None:
-            registry[name]["status"] = "invalid_configuration"
-            sys.stderr.write(f"invalid configuration for Node named {name}: missing 'collection' link")
-            continue
-        if version_url is None:
-            registry[name]["status"] = "invalid_configuration"
-            sys.stderr.write(f"invalid configuration for Node named {name}: missing 'version' link")
-            continue
         try:
-            services_response = requests.get(services_url)
-            version_response = requests.get(version_url)
+            # This assumes the json is initially valid according to the schema
+            services_response = requests.get(services_url, headers={"Accept": "application/json"})
+            version_response = requests.get(version_url, headers={"Accept": "application/json"})
         except requests.exceptions.ConnectionError as e:
             # if either url fails, report that the node is offline
             data["status"] = "offline"

--- a/doc/node_registry.example.json
+++ b/doc/node_registry.example.json
@@ -1,10 +1,30 @@
 {
   "UofT": {
-    "url": "http://daccs-uoft.example.com",
     "date_added": "2023-05-04T17:09:07+0000",
     "affiliation": "University of Toronto",
     "description": "This is the best node there is!",
-    "icon_url": "https://icon.example.com",
+    "links": [
+      {
+        "rel": "service",
+        "type": "text/html",
+        "href": "http://daccs-uoft.example.com"
+      },
+      {
+        "rel": "icon",
+        "type": "image/x-icon",
+        "href": "https://icon.example.com"
+      },
+      {
+        "rel": "collection",
+        "type": "application/json",
+        "href": "http://daccs-uoft.example.com/services"
+      },
+      {
+        "rel": "version",
+        "type": "application/json",
+        "href": "http://daccs-uoft.example.com/version"
+      }
+    ],
     "location": {
       "longitude": -79.39,
       "latitude": 43.65

--- a/node_registry.json
+++ b/node_registry.json
@@ -1,35 +1,95 @@
 {
   "UofT": {
-    "url": "https://daccs.cs.toronto.edu",
     "affiliation": "University of Toronto",
     "description": "A DACCS node hosted at the University of Toronto.",
-    "icon_url": "https://daccs.cs.toronto.edu/logo",
     "location": {
       "longitude": -79.39,
       "latitude": 43.65
     },
-    "contact": "daccs-info@cs.toronto.edu"
+    "contact": "daccs-info@cs.toronto.edu",
+    "links": [
+      {
+        "rel": "service",
+        "type": "text/html",
+        "href": "https://daccs.cs.toronto.edu"
+      },
+      {
+        "rel": "icon",
+        "type": "image/png",
+        "href": "https://daccs.cs.toronto.edu/logo"
+      },
+      {
+        "rel": "collection",
+        "type": "application/json",
+        "href": "https://daccs.cs.toronto.edu/services"
+      },
+      {
+        "rel": "version",
+        "type": "application/json",
+        "href": "https://daccs.cs.toronto.edu/version"
+      }
+    ]
   },
   "PAVICS": {
-    "url": "https://pavics.ouranos.ca",
     "affiliation": "Ouranos",
     "description": "PAVICS is a virtual laboratory facilitating the analysis of climate data.",
-    "icon_url": "https://pavics.ouranos.ca/assets/images/pavics_v_white.svg",
     "location": {
       "longitude": -73.57,
       "latitude": 45.5
     },
-    "contact": "pavics@ouranos.ca"
+    "contact": "pavics@ouranos.ca",
+    "links": [
+      {
+        "rel": "service",
+        "type": "text/html",
+        "href": "https://pavics.ouranos.ca"
+      },
+      {
+        "rel": "icon",
+        "type": "image/svg",
+        "href": "https://pavics.ouranos.ca/assets/images/pavics_v_white.svg"
+      },
+      {
+        "rel": "collection",
+        "type": "application/json",
+        "href": "https://pavics.ouranos.ca/services"
+      },
+      {
+        "rel": "version",
+        "type": "application/json",
+        "href": "https://pavics.ouranos.ca/version"
+      }
+    ]
   },
   "Hirondelle": {
-    "url": "https://hirondelle.crim.ca",
     "affiliation": "Computer Research Institute of Montréal (CRIM)",
     "description": "Development server to evaluate new features of the bird-house deployment architecture.",
-    "icon_url": "https://www.crim.ca/wp-content/uploads/2020/10/logo-color-300x61.png",
     "location": {
       "longitude": -73.627318,
       "latitude": 45.5303976
     },
-    "contact": "info@crim.ca"
+    "contact": "info@crim.ca",
+    "links": [
+      {
+        "rel": "service",
+        "type": "text/html",
+        "href": "https://hirondelle.crim.ca"
+      },
+      {
+        "rel": "icon",
+        "type": "image/svg",
+        "href": "https://www.crim.ca/wp-content/uploads/2020/10/logo-color-300x61.png"
+      },
+      {
+        "rel": "collection",
+        "type": "application/json",
+        "href": "https://hirondelle.crim.ca/services"
+      },
+      {
+        "rel": "version",
+        "type": "application/json",
+        "href": "https://hirondelle.crim.ca/version"
+      }
+    ]
   }
 }

--- a/node_registry.schema.json
+++ b/node_registry.schema.json
@@ -4,11 +4,6 @@
     "^[a-zA-Z0-9_-]+$": {
       "type": "object",
       "properties": {
-        "url": {
-          "type": "string",
-          "format": "uri",
-          "pattern": "^https?://"
-        },
         "date_added": {
           "type": "string",
           "format": "date-time"
@@ -18,11 +13,6 @@
         },
         "description": {
           "type": "string"
-        },
-        "icon_url": {
-          "type": "string",
-          "format": "uri",
-          "pattern": "^https?://"
         },
         "location": {
           "required": [
@@ -42,6 +32,47 @@
               "maximum": 180
             }
           }
+        },
+        "links": {
+          "type": "array",
+          "items": {
+            "$ref": "https://json-schema.org/draft/2020-12/links"
+          },
+          "allOf": [
+            {
+              "contains": {
+                "type": "object",
+                "properties": {
+                  "rel": {
+                    "type": "string",
+                    "const": "collection"
+                  }
+                }
+              }
+            },
+            {
+              "contains": {
+                "type": "object",
+                "properties": {
+                  "rel": {
+                    "type": "string",
+                    "const": "version"
+                  }
+                }
+              }
+            },
+            {
+              "contains": {
+                "type": "object",
+                "properties": {
+                  "rel": {
+                    "type": "string",
+                    "const": "service"
+                  }
+                }
+              }
+            }
+          ]
         },
         "services": {
           "type": "array",
@@ -125,9 +156,9 @@
         }
       },
       "required": [
-        "url",
         "date_added",
-        "contact"
+        "contact",
+        "links"
       ],
       "additionalProperties": false
     }

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -18,7 +18,7 @@ def links_json_schema(requests_mock, request):
 
 @pytest.fixture
 def registry_content(request):
-    """Return the content contained in ../doc/node_registry.example.json"""
+    """Return the content contained in node_registry.json"""
     root_dir = os.path.dirname(os.path.dirname(request.fspath))
     example_registry = os.path.join(root_dir, "node_registry.json")
     with open(example_registry) as f:
@@ -28,10 +28,10 @@ def registry_content(request):
 
 @pytest.fixture
 def schema_content(request):
-    """Return the content contained in ../doc/node_registry.example.json"""
+    """Return the content contained in node_registry.schema.json"""
     root_dir = os.path.dirname(os.path.dirname(request.fspath))
-    example_registry = os.path.join(root_dir, "node_registry.schema.json")
-    with open(example_registry) as f:
+    example_schema = os.path.join(root_dir, "node_registry.schema.json")
+    with open(example_schema) as f:
         content = json.load(f)
     return content
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,40 @@
+import os
+
+import json
+import jsonschema
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def links_json_schema(requests_mock, request):
+    """
+    Mock the `requests.get` call to the json-schema links hyper-schema so that these tests can be run offline if needed.
+    """
+    this_dir = os.path.dirname(request.fspath)
+    with open(os.path.join(this_dir, "fixtures", "links-schema-cache.json")) as f:
+        content = f.read()
+    requests_mock.get("https://json-schema.org/draft/2020-12/links", text=content)
+
+
+@pytest.fixture
+def registry_content(request):
+    """Return the content contained in ../doc/node_registry.example.json"""
+    root_dir = os.path.dirname(os.path.dirname(request.fspath))
+    example_registry = os.path.join(root_dir, "node_registry.json")
+    with open(example_registry) as f:
+        content = json.load(f)
+    return content
+
+
+@pytest.fixture
+def schema_content(request):
+    """Return the content contained in ../doc/node_registry.example.json"""
+    root_dir = os.path.dirname(os.path.dirname(request.fspath))
+    example_registry = os.path.join(root_dir, "node_registry.schema.json")
+    with open(example_registry) as f:
+        content = json.load(f)
+    return content
+
+
+def test_valid_registry(registry_content, schema_content):
+    jsonschema.validate(registry_content, schema_content)

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -157,8 +157,10 @@ class TestNodeReturnsInvalidJson:
 
     @pytest.fixture(autouse=True)
     def setup(self, example_node_name, example_registry, example_registry_content, requests_mock):
-        requests_mock.get(os.path.join(example_registry_content[example_node_name]["url"], "services"), text='{"a":')
-        requests_mock.get(os.path.join(example_registry_content[example_node_name]["url"], "version"), text="1.2.3")
+        services_url = next(link["href"] for link in example_registry_content[example_node_name]["links"] if link["rel"] == "collection")
+        version_url = next(link["href"] for link in example_registry_content[example_node_name]["links"] if link["rel"] == "version")
+        requests_mock.get(services_url, text='{"a":')
+        requests_mock.get(version_url, text="1.2.3")
         update.update_registry()
 
     def test_status_unresponsive(self, example_node_name, example_registry_content, updated_registry):
@@ -195,11 +197,13 @@ class InitialTests:
 
     @pytest.fixture(autouse=True)
     def setup(self, example_node_name, example_initial_registry, example_registry_content, requests_mock):
+        services_url = next(link["href"] for link in example_registry_content[example_node_name]["links"] if link["rel"] == "collection")
+        version_url = next(link["href"] for link in example_registry_content[example_node_name]["links"] if link["rel"] == "version")
         requests_mock.get(
-            os.path.join(example_registry_content[example_node_name]["url"], "services"), json=self.services
+            services_url, json=self.services
         )
         requests_mock.get(
-            os.path.join(example_registry_content[example_node_name]["url"], "version"), json=self.version
+            version_url, json=self.version
         )
         update.update_registry()
 
@@ -212,11 +216,13 @@ class NonInitialTests:
 
     @pytest.fixture(autouse=True)
     def setup(self, example_node_name, example_registry, example_registry_content, requests_mock):
+        services_url = next(link["href"] for link in example_registry_content[example_node_name]["links"] if link["rel"] == "collection")
+        version_url = next(link["href"] for link in example_registry_content[example_node_name]["links"] if link["rel"] == "version")
         requests_mock.get(
-            os.path.join(example_registry_content[example_node_name]["url"], "services"), json=self.services
+            services_url, json=self.services
         )
         requests_mock.get(
-            os.path.join(example_registry_content[example_node_name]["url"], "version"), json=self.version
+            version_url, json=self.version
         )
         update.update_registry()
 


### PR DESCRIPTION
As suggested in #10, this does the following:

- creates a `links` key for each node
- replaces the `url` key with an entry in `links` (`rel` = `service`)
- replaces the `icon_url` key with an entry in `links` (`rel` = `icon`)
- requires a `rel` = `version` entry in `links` (refers to the `/version` endpoint)
- requires a `rel` = `collection` entry in `links` (refers the the `/services` endpoint)
- suggests other potential links values in the README.md file

Resolves #10