### PR TITLE
Uoft update

### DIFF
--- a/node_registry.json
+++ b/node_registry.json
@@ -1,7 +1,7 @@
 {
   "UofT": {
     "affiliation": "University of Toronto",
-    "description": "A DACCS node hosted at the University of Toronto.",
+    "description": "A Marble node hosted at the University of Toronto.",
     "location": {
       "longitude": -79.39,
       "latitude": 43.65


### PR DESCRIPTION
This is an update to the content of the registry itself.

Two changes are made:
1. Remove reference to DACCS from the description of the UofT node
2. update repository address from DACCS-node-registry to Marble-node-registry.