### PR TITLE
add name field to registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ If you are already part of the Marble Network and details about your node have c
 In which case, please submit the pull request with the new URL and the Executive Committee will approve it quickly.
 
 When making changes to the node_registry.json file please only change or add the following values:
+  - `name` (the name of your node, to be displayed to users)
   - `affiliation` (the name of your organization, optional)
   - `description` (a short description of your node, optional)
   - `location` (latitude and longitude of your organization, optional)

--- a/doc/node_registry.example.json
+++ b/doc/node_registry.example.json
@@ -1,5 +1,6 @@
 {
   "UofT": {
+    "name": "UofT",
     "date_added": "2023-05-04T17:09:07+0000",
     "affiliation": "University of Toronto",
     "description": "This is the best node there is!",

--- a/node_registry.json
+++ b/node_registry.json
@@ -1,6 +1,6 @@
 {
-  "UofT": {
-    "name": "UofT",
+  "UofTRedOak": {
+    "name": "Red Oak",
     "affiliation": "University of Toronto",
     "description": "A Marble node hosted at the University of Toronto.",
     "location": {

--- a/node_registry.json
+++ b/node_registry.json
@@ -1,5 +1,6 @@
 {
   "UofT": {
+    "name": "UofT",
     "affiliation": "University of Toronto",
     "description": "A Marble node hosted at the University of Toronto.",
     "location": {
@@ -31,6 +32,7 @@
     ]
   },
   "PAVICS": {
+    "name": "PAVICS",
     "affiliation": "Ouranos",
     "description": "PAVICS is a virtual laboratory facilitating the analysis of climate data.",
     "location": {
@@ -62,6 +64,7 @@
     ]
   },
   "Hirondelle": {
+    "name": "Hirondelle",
     "affiliation": "Computer Research Institute of Montréal (CRIM)",
     "description": "Development server to evaluate new features of the bird-house deployment architecture.",
     "location": {

--- a/node_registry.schema.json
+++ b/node_registry.schema.json
@@ -4,6 +4,9 @@
     "^[a-zA-Z0-9_-]+$": {
       "type": "object",
       "properties": {
+        "name": {
+          "type": "string"
+        },
         "date_added": {
           "type": "string",
           "format": "date-time"
@@ -157,7 +160,8 @@
       },
       "required": [
         "contact",
-        "links"
+        "links",
+        "name"
       ],
       "additionalProperties": false
     }

--- a/node_registry.schema.json
+++ b/node_registry.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "patternProperties": {
-    "^[a-zA-Z0-9_-]+$": {
+    "^[a-zA-Z0-9]+$": {
       "type": "object",
       "properties": {
         "name": {


### PR DESCRIPTION
Make the top-level keys in the registry object a unique identifier that is decoupled from the name of the node itself.

Add a name field for each node that should be used to display the name of the node to end users. The top-level key should be exclusively used to uniquely identify a node.

Resolves #30