### PR TITLE
add registration info to registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ When making changes to the node_registry.json file please only change or add the
   - `description` (a short description of your node, optional)
   - `location` (latitude and longitude of your organization, optional)
   - `contact` (an email address that can be used by users to contact you if they have questions about your node)
+  - `registration_status` (indicates whether the node is currently accepting new users or not)
+    - values must be one of:
+      - `open`: accepting new registration requests
+      - `limited`: accepting new registrations under limited circumstances
+      - `closed`: not accepting new registration requests
   - `links` (contains a list of link objects that describe URLs for each node)
     - each link object must contain a `rel` and `href` key. 
     - some link objects are required, see the table below for details
@@ -57,6 +62,7 @@ for a description of some link values that may be useful.
 | `copyright` <br> `license` <br> `terms-of-service` | link to legal information of the node                                                      |          |
 | `describedby`                                      | link to full documentation and details of the node, its purpose and so on                  |          |
 | `edit`                                             | A self-reference to this repo or anywhere a user can request an update to a node           |          |
+| `registration`                                     | link to a page or email address where a new user can request an account                    |          |
 | `service`                                          | link to the landing page of the node                                                       | Yes      |
 | `service-desc`                                     | link to the `/components` endpoint of the node                                             |          |
 | `icon`                                             | link to the logo of the specific node (or the maintainer/institution's logo)               |          |

--- a/doc/node_registry.example.json
+++ b/doc/node_registry.example.json
@@ -3,6 +3,7 @@
     "date_added": "2023-05-04T17:09:07+0000",
     "affiliation": "University of Toronto",
     "description": "This is the best node there is!",
+    "registration_status": "open",
     "links": [
       {
         "rel": "service",

--- a/node_registry.json
+++ b/node_registry.json
@@ -81,7 +81,7 @@
       "latitude": 45.5303976
     },
     "contact": "info@crim.ca",
-    "registration_status": "closed",
+    "registration_status": "limited",
     "links": [
       {
         "rel": "service",
@@ -102,6 +102,10 @@
         "rel": "version",
         "type": "application/json",
         "href": "https://hirondelle.crim.ca/version"
+      },
+      {
+        "rel": "registration",
+        "href": "mailto:support-geo@crim.ca"
       }
     ]
   }

--- a/node_registry.json
+++ b/node_registry.json
@@ -7,6 +7,7 @@
       "latitude": 43.65
     },
     "contact": "daccs-info@cs.toronto.edu",
+    "registration_status": "limited",
     "links": [
       {
         "rel": "service",
@@ -27,6 +28,11 @@
         "rel": "version",
         "type": "application/json",
         "href": "https://daccs.cs.toronto.edu/version"
+      },
+      {
+        "rel": "registration",
+        "type": "text/html",
+        "href": "https://docs.google.com/forms/d/e/1FAIpQLSf3w3bBBkEcI7ehonci56rQnHsz-OPltnbwls9KogvhXWxTFQ/viewform"
       }
     ]
   },
@@ -38,6 +44,7 @@
       "latitude": 45.5
     },
     "contact": "pavics@ouranos.ca",
+    "registration_status": "limited",
     "links": [
       {
         "rel": "service",
@@ -58,6 +65,11 @@
         "rel": "version",
         "type": "application/json",
         "href": "https://pavics.ouranos.ca/version"
+      },
+      {
+        "rel": "registration",
+        "type": "text/html",
+        "href": "https://forms.office.com/Pages/ResponsePage.aspx?id=jf6iw_Q8V02umCWsOYvz8Pa-ghpkFLtEhY0_uNsYGzNUM0RKREtBODQ4S0ZXNEZEUFlZRExJWkhVQSQlQCN0PWcu"
       }
     ]
   },
@@ -69,6 +81,7 @@
       "latitude": 45.5303976
     },
     "contact": "info@crim.ca",
+    "registration_status": "closed",
     "links": [
       {
         "rel": "service",

--- a/node_registry.schema.json
+++ b/node_registry.schema.json
@@ -153,11 +153,20 @@
         "contact": {
           "type": "string",
           "format": "email"
+        },
+        "registration_status": {
+          "type": "string",
+          "enum": [
+            "open",
+            "limited",
+            "closed"
+          ]
         }
       },
       "required": [
         "contact",
-        "links"
+        "links",
+        "registration_status"
       ],
       "additionalProperties": false
     }


### PR DESCRIPTION
Adds the following optional information to the registry:

- Each node should include a link to a registration page (can be email address, web page, web form, etc.)
- Each node should also include a registration status indicating whether they are currently accepting new registrations

This may be used to show potential new users which nodes to consider if they are looking to register.

Resolves #31