### PR TITLE
No automatic date added

### DIFF
--- a/doc/admin-instructions.md
+++ b/doc/admin-instructions.md
@@ -19,3 +19,13 @@ The following steps must be taken by a user with "Admin" or "Maintainer" level p
     - Create a new repository secret name `DACCS_NODE_REGISTRY_PAT` with the value of the token from step 1
 
 Remember that if you set an expiry date for this token you'll need to repeat these steps when the token expires.
+
+## Manual steps when adding a new node
+
+Before adding a new node to the registry for the first time, ensure that the node has the `date_added` field included
+in the registry. This should be an iso formatted datetime string which can be generated with the following snippet:
+
+```python
+import datetime
+datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
+```

--- a/marble_node_registry/update.py
+++ b/marble_node_registry/update.py
@@ -96,8 +96,6 @@ def update_registry() -> None:
         else:
             print(f"successfully updated Node named {name}")
             registry[name]["last_updated"] = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
-            if registry[name].get("date_added") is None:
-                registry[name]["date_added"] = registry[name]["last_updated"]
             data["status"] = "online"
 
     _write_registry(registry)

--- a/node_registry.json
+++ b/node_registry.json
@@ -3,6 +3,7 @@
     "name": "Red Oak",
     "affiliation": "University of Toronto",
     "description": "A Marble node hosted at the University of Toronto.",
+    "date_added": "2023-07-13T01:03:30.933732+00:00",
     "location": {
       "longitude": -79.39,
       "latitude": 43.65
@@ -41,6 +42,7 @@
     "name": "PAVICS",
     "affiliation": "Ouranos",
     "description": "PAVICS is a virtual laboratory facilitating the analysis of climate data.",
+    "date_added": "2023-07-13T01:03:30.933732+00:00",
     "location": {
       "longitude": -73.57,
       "latitude": 45.5
@@ -79,6 +81,7 @@
     "name": "Hirondelle",
     "affiliation": "Computer Research Institute of Montréal (CRIM)",
     "description": "Development server to evaluate new features of the bird-house deployment architecture.",
+    "date_added": "2023-07-13T01:03:30.933732+00:00",
     "location": {
       "longitude": -73.627318,
       "latitude": 45.5303976

--- a/node_registry.schema.json
+++ b/node_registry.schema.json
@@ -170,7 +170,8 @@
         "contact",
         "links",
         "name",
-        "registration_status"
+        "registration_status",
+        "date_added"
       ],
       "additionalProperties": false
     }


### PR DESCRIPTION
Previously the `date_added` field was automatically added to the registry the first time that the update.py script was run for that node. This was done by checking whether the registry already had the `date_added` field for the given node and adding one if it was missing. 

However, when executing the update.py script in the CI workflow, we read the registry from the `main` branch and apply the changes to the `current_registry` branch. This means that the `date_added` field is never added to the `main` branch, which means that the update.py script re-adds the `date_added` field every time.

This PR makes the `date_added` field into a manually added field that should be included when a new node is added. This adds another (very small) manual step when adding a new node but with the current CI configuration there's no good way to do this automatically anymore.

I've also updated the schema so it should be obvious when the `date_added` information is missing. This means we won't forget to add this info when adding new nodes.