### PR TITLE
Fix invalid schema if unresponsive or invalid error

### DIFF
--- a/marble_node_registry/update.py
+++ b/marble_node_registry/update.py
@@ -34,7 +34,7 @@ def _write_registry(registry: dict) -> None:
     """
     Write the registry as a json string to the 'node_registry.json' file.
     """
-    with open(CURRENT_REGISTRY, "w") as f:
+    with open(CURRENT_REGISTRY + ".new", "w") as f: # TODO: revert this... for testing only
         json.dump(registry, f, indent=2)
 
 
@@ -91,7 +91,7 @@ def update_registry() -> None:
             jsonschema.validate(instance=registry, schema=schema)
         except jsonschema.exceptions.ValidationError as e:
             registry[name] = org_data
-            registry[name]["status"] = "invalid_configuration"
+            registry[name]["status"] = "unknown"
             sys.stderr.write(f"invalid configuration for Node named {name}: {e}\n")
         else:
             print(f"successfully updated Node named {name}")

--- a/marble_node_registry/update.py
+++ b/marble_node_registry/update.py
@@ -34,7 +34,7 @@ def _write_registry(registry: dict) -> None:
     """
     Write the registry as a json string to the 'node_registry.json' file.
     """
-    with open(CURRENT_REGISTRY + ".new", "w") as f: # TODO: revert this... for testing only
+    with open(CURRENT_REGISTRY, "w") as f:
         json.dump(registry, f, indent=2)
 
 
@@ -70,8 +70,7 @@ def update_registry() -> None:
         try:
             data["version"] = version_response.json().get("version", "unknown")
         except requests.exceptions.JSONDecodeError:
-            registry[name] = org_data
-            registry[name]["status"] = "unresponsive"
+            data["status"] = "unresponsive"
             sys.stderr.write(
                 f"invalid json returned when accessing version for Node named {name}: {version_response.text}\n"
             )
@@ -80,8 +79,7 @@ def update_registry() -> None:
         try:
             data["services"] = services_response.json().get("services", [])
         except requests.exceptions.JSONDecodeError:
-            registry[name] = org_data
-            registry[name]["status"] = "unresponsive"
+            data["status"] = "unresponsive"
             sys.stderr.write(
                 f"invalid json returned when accessing services for Node named {name}: {services_response.text}\n"
             )
@@ -90,12 +88,11 @@ def update_registry() -> None:
         try:
             jsonschema.validate(instance=registry, schema=schema)
         except jsonschema.exceptions.ValidationError as e:
-            registry[name] = org_data
-            registry[name]["status"] = "unknown"
+            registry[name] = {**org_data, "status": "invalid_configuration"}  # do not include services data if it is invalid
             sys.stderr.write(f"invalid configuration for Node named {name}: {e}\n")
         else:
             print(f"successfully updated Node named {name}")
-            registry[name]["last_updated"] = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
+            data["last_updated"] = datetime.datetime.now(tz=datetime.timezone.utc).isoformat()
             data["status"] = "online"
 
     _write_registry(registry)

--- a/node_registry.schema.json
+++ b/node_registry.schema.json
@@ -79,7 +79,8 @@
           "type": "string",
           "enum": [
             "offline",
-            "online"
+            "online",
+            "unknown"
           ]
         },
         "contact": {

--- a/node_registry.schema.json
+++ b/node_registry.schema.json
@@ -80,7 +80,8 @@
           "enum": [
             "offline",
             "online",
-            "unknown"
+            "unresponsive",
+            "invalid_configuration"
           ]
         },
         "contact": {

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -2,6 +2,7 @@ import json
 import os
 from copy import deepcopy
 
+import jsonschema
 import pytest
 
 from marble_node_registry import update
@@ -104,6 +105,10 @@ def example_registry(patched_registry, example_registry_content):
 def example_node_name(example_registry_content):
     """Return the name of the node in example_registry_content"""
     return list(example_registry_content)[0]
+
+@pytest.fixture
+def node_registry_schema():
+    return update._load_schema()
 
 
 class TestEmptyRegistry:
@@ -260,6 +265,9 @@ class ValidResponseTests:
             example_node_name
         ].get("last_updated")
 
+    def test_final_registry_valid(self, updated_registry, node_registry_schema):
+        jsonschema.validate(instance=updated_registry.call_args.args[0], schema=node_registry_schema)
+
 
 class InvalidResponseTests:
     """
@@ -291,6 +299,9 @@ class InvalidResponseTests:
         assert updated_registry.call_args.args[0][example_node_name].get("last_updated") == example_registry_content[
             example_node_name
         ].get("last_updated")
+
+    def test_final_registry_valid(self, updated_registry, node_registry_schema):
+        jsonschema.validate(instance=updated_registry.call_args.args[0], schema=node_registry_schema)
 
 
 class TestInitialUpdateNoServices(ValidResponseTests, InitialTests):


### PR DESCRIPTION
If the status was set to "unresponsive" or "invalid_configuration" during an update, these would lead to an invalid schema since those statuses were not technically part of the schema. 

This fixes that by adding those statuses to the schema and adds some tests to ensure that the final schema is always valid even if the services reported by the schema are themselves invalid.