### PR TITLE
replace keywords with types and relax restrictions on keywords

### DIFF
--- a/doc/node_registry.example.json
+++ b/doc/node_registry.example.json
@@ -41,6 +41,12 @@
           "service-wms",
           "service-wfs"
         ],
+        "types": [
+          "data",
+          "wps",
+          "wms",
+          "wfs"
+        ],
         "description": "GeoServer is a server that allows users to view and edit geospatial data.",
         "links": [
           {
@@ -59,6 +65,9 @@
         "name": "weaver",
         "keywords": [
           "service-ogcapi_processes"
+        ],
+        "types": [
+          "ogcapi_processes"
         ],
         "description": "An OGC-API flavored Execution Management Service",
         "links": [

--- a/marble_node_registry/migrations.py
+++ b/marble_node_registry/migrations.py
@@ -1,0 +1,46 @@
+# Migrations are used to ensure that data provided by nodes that are using an
+# older version of the schema are updated automatically to comply with the newest
+# version of the schema.
+#
+# If a backwards incompatible change is introduced in the schema, please make a 
+# new migration function here to ensure that older data is properly updated.
+#
+# Migration functions will be applied to each node's data in the order that they
+# appear in the MIGRATIONS variable at the bottom of this file.
+#
+# All migration function should take a single argument which contains the node's
+# data and modify that data in place.
+
+def convert_keywords_to_types(data: dict) -> None:
+    """
+    Add service types if they don't exist.
+
+    Since version 1.3.0 service "types" are now required. If they don't exist
+    then they can be derived from service "keywords" which were used in place
+    of "types" prior to this version.
+    """
+
+    keyword2type = {
+        "catalog": "catalog",
+        "data": "data",
+        "jupyterhub": "jupyterhub",
+        "other": "other",
+        "service-wps": "wps",
+        "service-wms": "wms",
+        "service-wfs": "wfs",
+        "service-wcs": "wcs",
+        "service-ogcapi_processes": "ogcapi_processes"
+    }
+    for service in data["services"]:
+        if "types" not in service:
+            service["types"] = []
+            for keyword in service["keywords"]:
+                if (type_ := keyword2type.get(keyword)):
+                    service["types"].append(type_)
+            if not service["types"]:
+                service["types"].append("other")
+
+
+MIGRATIONS = (
+    convert_keywords_to_types,
+)

--- a/marble_node_registry/update.py
+++ b/marble_node_registry/update.py
@@ -6,6 +6,8 @@ import requests
 import datetime
 from copy import deepcopy
 
+from migrations import MIGRATIONS
+
 THIS_DIR = os.path.dirname(__file__)
 ROOT_DIR = os.path.dirname(THIS_DIR)
 SCHEMA_FILE = os.path.join(ROOT_DIR, "node_registry.schema.json")
@@ -85,6 +87,15 @@ def update_registry() -> None:
             sys.stderr.write(
                 f"invalid json returned when accessing services for Node named {name}: {services_response.text}\n"
             )
+            continue
+
+        try:
+            for migration in MIGRATIONS:
+                migration(data)
+        except Exception as e:
+            registry[name] = org_data
+            registry[name]["status"] = "invalid_configuration"
+            sys.stderr.write(f"unable to apply migrations for Node named {name}: {e}.")
             continue
 
         try:

--- a/node_registry.schema.json
+++ b/node_registry.schema.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/DACCS-Climate/Marble-node-registry/refs/tags/1.2.0/node_registry.schema.json",
   "patternProperties": {
     "^[a-zA-Z0-9]+$": {
       "type": "object",
@@ -167,6 +168,7 @@
               "auth",
               "management",
               "catalog",
+              "stac",
               "data",
               "jupyterhub",
               "other",
@@ -175,7 +177,10 @@
               "wfs",
               "wcs",
               "ogcapi_processes",
-              "ogcapi_dggs"
+              "ogcapi_dggs",
+              "ogcapi_coverages",
+              "ogcapi_features",
+              "ogcapi_records"
             ]
           }
         },

--- a/node_registry.schema.json
+++ b/node_registry.schema.json
@@ -148,6 +148,7 @@
       "type": "object",
       "required": [
         "name",
+        "types",
         "keywords",
         "description",
         "links"
@@ -157,12 +158,32 @@
           "type": "string",
           "minLength": 1
         },
-        "keywords": {
+        "types": {
           "type": "array",
           "minItems": 1,
           "items": {
             "type": "string",
-            "pattern": "^catalog|data|jupyterhub|other|service-(wps|wms|wfs|wcs|ogcapi_processes)$"
+            "enum": [
+              "auth",
+              "management",
+              "catalog",
+              "data",
+              "jupyterhub",
+              "other",
+              "wps",
+              "wms",
+              "wfs",
+              "wcs",
+              "ogcapi_processes",
+              "ogcapi_dggs"
+            ]
+          }
+        },
+        "keywords": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
           }
         },
         "description": {

--- a/node_registry.schema.json
+++ b/node_registry.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/DACCS-Climate/Marble-node-registry/refs/tags/1.2.0/node_registry.schema.json",
+  "$id": "https://raw.githubusercontent.com/DACCS-Climate/Marble-node-registry/refs/tags/1.3.0/node_registry.schema.json",
   "patternProperties": {
     "^[a-zA-Z0-9]+$": {
       "type": "object",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,4 +2,4 @@
 addopts = [
     "--import-mode=importlib",
 ]
-pythonpath = "."
+pythonpath = "./marble_node_registry"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -35,6 +35,7 @@ def registry_content_with_services(registry_content):
         {
             "name": "test-service",
             "keywords": ["other"],
+            "types": ["other"],
             "description": "test service",
             "version": "1.2.3",
             "links": [

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -267,7 +267,7 @@ class ValidResponseTests:
             example_node_name
         ].get("last_updated")
 
-    def test_final_registry_valid(self, updated_registry, node_registry_schema):
+    def test_final_registry_validity(self, updated_registry, node_registry_schema):
         jsonschema.validate(instance=updated_registry.call_args.args[0], schema=node_registry_schema)
 
 
@@ -302,7 +302,7 @@ class InvalidResponseTests:
             example_node_name
         ].get("last_updated")
 
-    def test_final_registry_valid(self, updated_registry, node_registry_schema):
+    def test_final_registry_validity(self, updated_registry, node_registry_schema):
         jsonschema.validate(instance=updated_registry.call_args.args[0], schema=node_registry_schema)
 
 


### PR DESCRIPTION
As discussed in #39 this will replace service "keywords" with "types" and allow keywords to be any string.

This also introduces a mechanism to automatically migrate older versions of the schema to be compatible with the newest version so that we can support nodes that provide older data without needing everyone to update at once.

Resolves #39